### PR TITLE
Identify users to have personal tokens

### DIFF
--- a/apps/token/TokenGenerator.py
+++ b/apps/token/TokenGenerator.py
@@ -23,18 +23,25 @@ class TokenGenerator:
         """
         current_directory = os.path.dirname(os.path.abspath(__file__))
         self.html_file_path = f"file:///{current_directory}/token.html"
+        self.user_agents = {}
 
-    def get_token(self):
+    def get_token(self, user_id):
         """
         Get a token from the HTML file.
+        
+        Checks the dictionary for a user agent for the given user_id.
+        If a match is not found, generates a new random user agent and saves it in the dictionary.
+        If a match is found, uses the saved user agent from the dictionary for that user_id.
 
         Waits for the presence of a specific div element in the HTML file and returns its text content as the token.
 
         Returns:
         - str: The generated token.
         """
+        if user_id not in self.user_agents:
+            self.user_agents[user_id] = FakeUserAgent().random
+        random_useragent = self.user_agents[user_id]
         with sync_playwright() as playwright:
-            random_useragent = FakeUserAgent().random
             browser = playwright.chromium.launch(headless=True)
             context = browser.new_context(user_agent=random_useragent)
             page = context.new_page()

--- a/apps/token/routes.py
+++ b/apps/token/routes.py
@@ -2,7 +2,7 @@ import logging
 import os
 import time
 
-from flask import jsonify
+from flask import jsonify, request
 
 from apps.token import blueprint, logger, token_generator
 
@@ -10,8 +10,9 @@ from apps.token import blueprint, logger, token_generator
 @blueprint.route("/token", methods=["GET"])
 def token_route():
     try:
+        user_id = request.args.get('user_id')
         start_time = time.time()
-        token = token_generator.get_token()
+        token = token_generator.get_token(user_id)
         logger.info("Token generated in %s seconds" % (time.time() - start_time))
         return jsonify(token), 200
     except Exception:


### PR DESCRIPTION
Simple working concept for making individual tokens based on the user's encoded email address. Only requires Ikabot clients to encode self.mail and send it to the API as an additional param.